### PR TITLE
[TASK] Specify library explicitly

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,7 +14,6 @@ verifier:
 
 platforms:
   - name: ubuntu-16.04
-  - name: centos-7.2
 
 suites:
   - name: default

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
-@Library('github.com/TYPO3-infrastructure/jenkins-pipeline-global-library-chefci@testing')
-def dummy
-org.typo3.chefci.v2.Pipeline.builder(this, steps)
+@Library('chefci@testing') _
+org.typo3.chefci.v2.cookbook.CookbookPipeline.builder(this, steps)
 	.buildDefaultPipeline()
 	.execute()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('github.com/TYPO3-infrastructure/jenkins-pipeline-global-library-chefci@master')
+@Library('github.com/TYPO3-infrastructure/jenkins-pipeline-global-library-chefci@testing')
 def dummy
 org.typo3.chefci.v2.Pipeline.builder(this, steps)
 	.buildDefaultPipeline()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,14 +1,5 @@
-// Build a pipeline with custom steps:
-
-/*
-org.typo3.chefci.v2.Pipeline.builder(this, steps)
-  .withHelloWorldStage()
-  .build()
-  .execute()
-*/
-
-// Build a default pipeline
-
+@Library('github.com/TYPO3-infrastructure/jenkins-pipeline-global-library-chefci@master')
+def dummy
 org.typo3.chefci.v2.Pipeline.builder(this, steps)
 	.buildDefaultPipeline()
 	.execute()


### PR DESCRIPTION
Some people (fabric8) say that this is the better way.
Esp. the `dummy` that has to be added feels bit dull. OTOH, I think it makes it clearer for everyone, where all these functions originate.

What do you think?